### PR TITLE
Renames theme from courtyard to mitlib-courtyard

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
-# Travis CI (MIT License) configuration file for the Courtyard WordPress theme.
+# Travis CI (MIT License) configuration file for the Mitlib-Courtyard WordPress theme.
 # This has been adapted from Underscores.
 # @link https://travis-ci.org/
 
 # For use with the Courtyard WordPress theme, based on Underscores
-# @link https://github.com/MITLibraries/courtyard
+# @link https://github.com/MITLibraries/mitlib-courtyard
 
 # Declare what Travis environment should be used. Specifically, we need the
 # 'precise' environment rather than 'trusty' to get PHP 5.3.

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,7 +77,7 @@ before_script:
   # Install CodeSniffer for WordPress Coding Standards checks.
   - git clone https://github.com/squizlabs/PHP_CodeSniffer.git php-codesniffer
   # Install WordPress Coding Standards.
-  - git clone https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git wordpress-coding-standards
+  - git clone master https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git wordpress-coding-standards
   # Hop into CodeSniffer directory.
   - cd php-codesniffer
   # Checkout pre 3.x version

--- a/404.php
+++ b/404.php
@@ -4,7 +4,7 @@
  *
  * @link https://codex.wordpress.org/Creating_an_Error_404_Page
  *
- * @package Courtyard
+ * @package mitlib-courtyard
  */
 
 get_header(); ?>

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-[![Build Status](https://travis-ci.org/MITLibraries/courtyard.svg)](https://travis-ci.org/MITLibraries/courtyard)
-[![Code Climate](https://codeclimate.com/github/MITLibraries/courtyard/badges/gpa.svg)](https://codeclimate.com/github/MITLibraries/courtyard)
-[![Stories in Ready](https://badge.waffle.io/MITLibraries/courtyard.svg?label=ready&title=Ready)](http://waffle.io/MITLibraries/courtyard)
+[![Build Status](https://travis-ci.org/MITLibraries/mitlib-courtyard.svg)](https://travis-ci.org/MITLibraries/mitlib-courtyard)
+[![Code Climate](https://codeclimate.com/github/MITLibraries/mitlib-courtyard/badges/gpa.svg)](https://codeclimate.com/github/MITLibraries/mitlib-courtyard)
+[![Stories in Ready](https://badge.waffle.io/MITLibraries/mitlib-courtyard.svg?label=ready&title=Ready)](http://waffle.io/MITLibraries/mitlib-courtyard)
 
-Courtyard
+Mitlib-Courtyard
 ======
 
-Courtyard is a base WordPress theme for use on internal projects at the MIT Libraries. It has been created by [Matt Bernhardt](https://github.com/matt-bernhardt) from the [_strap](https://github.com/ptbello/_strap) starter theme.
+Mitlib-Courtyard is a base WordPress theme for use on internal projects at the MIT Libraries. It has been created by [Matt Bernhardt](https://github.com/matt-bernhardt) from the [_strap](https://github.com/ptbello/_strap) starter theme.

--- a/archive.php
+++ b/archive.php
@@ -4,7 +4,7 @@
  *
  * @link https://codex.wordpress.org/Template_Hierarchy
  *
- * @package Courtyard
+ * @package mitlib-courtyard
  */
 
 get_header(); ?>

--- a/comments.php
+++ b/comments.php
@@ -7,7 +7,7 @@
  *
  * @link https://codex.wordpress.org/Template_Hierarchy
  *
- * @package Courtyard
+ * @package mitlib-courtyard
  */
 
 /*

--- a/css/style.css
+++ b/css/style.css
@@ -1,10 +1,10 @@
 /*
-Theme Name: Courtyard
-Theme URI: https://github.com/MITLibraries/courtyard/
+Theme Name: MITlib Courtyard
+Theme URI: https://github.com/mitlibraries/mitlib-courtyard
 Author: Matt Bernhardt
 Author URI: http://github.com/matt-bernhardt/
 Description: This is a parent / base theme that is meant as a scaffold for child sites. It is based on _strap.
-Version: 1.1.1-@@branch-@@commit
+Version: 1.2.0-@@branch-@@commit
 License: GNU General Public License
 License URI: license.txt
 Tags: bootstrap, _s, _strap

--- a/footer.php
+++ b/footer.php
@@ -6,7 +6,7 @@
  *
  * @link https://developer.wordpress.org/themes/basics/template-files/#template-partials
  *
- * @package Courtyard
+ * @package mitlib-courtyard
  */
 
 ?>

--- a/functions.php
+++ b/functions.php
@@ -1,10 +1,10 @@
 <?php
 /**
- * Courtyard functions and definitions.
+ * Mitlib-Courtyard functions and definitions.
  *
  * @link https://developer.wordpress.org/themes/basics/theme-functions/
  *
- * @package Courtyard
+ * @package mitlib-courtyard
  */
 
 if ( ! function_exists( 'courtyard_setup' ) ) :

--- a/header.php
+++ b/header.php
@@ -6,7 +6,7 @@
  *
  * @link https://developer.wordpress.org/themes/basics/template-files/#template-partials
  *
- * @package Courtyard
+ * @package mitlib-courtyard
  */
 
 ?><!DOCTYPE html>

--- a/inc/custom-header.php
+++ b/inc/custom-header.php
@@ -12,7 +12,7 @@
  *
  * @link http://codex.wordpress.org/Custom_Headers
  *
- * @package Courtyard
+ * @package mitlib-courtyard
  */
 
 /**

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -16,17 +16,19 @@ function courtyard_customize_register( $wp_customize ) {
 	$wp_customize->get_setting( 'header_textcolor' )->transport = 'postMessage';
 
 	// Implements ability to hide navbar.
+	$wp_customize->add_section('navbar_section', array(
+		'title' => 'Navbar',
+	));
+
 	$wp_customize->add_setting( 'hide_nav', array(
-			'type' => 'theme_mod',
-		)
-	);
+		'type' => 'theme_mod',
+	));
 	$wp_customize->add_control( 'hide_nav', array(
-			'type' => 'checkbox',
-			'priority' => '10',
-			'section' => 'nav',
-			'label' => __( 'Hide navbar' ),
-		)
-	);
+		'type' => 'checkbox',
+		'priority' => '10',
+		'section' => 'navbar_section',
+		'label' => __( 'Hide navbar' ),
+	));
 }
 add_action( 'customize_register', 'courtyard_customize_register' );
 

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * mitlib-courtyard Theme Customizer.
+ * Mitlib-courtyard Theme Customizer.
  *
  * @package mitlib-courtyard
  */

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * Courtyard Theme Customizer.
+ * mitlib-courtyard Theme Customizer.
  *
- * @package Courtyard
+ * @package mitlib-courtyard
  */
 
 /**

--- a/inc/extras.php
+++ b/inc/extras.php
@@ -4,7 +4,7 @@
  *
  * Eventually, some of the functionality here could be replaced by core features.
  *
- * @package Courtyard
+ * @package mitlib-courtyard
  */
 
 /**

--- a/inc/functions-strap.php
+++ b/inc/functions-strap.php
@@ -2,7 +2,7 @@
 /**
  * This needs to describe the functions-strap php file.
  *
- * @package Courtyard
+ * @package mitlib-courtyard
  */
 
 /**

--- a/inc/jetpack.php
+++ b/inc/jetpack.php
@@ -4,7 +4,7 @@
  *
  * @link https://jetpack.me/
  *
- * @package Courtyard
+ * @package mitlib-courtyard
  */
 
 /**

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -118,4 +118,4 @@ function courtyard_category_transient_flusher() {
 	delete_transient( 'courtyard_categories' );
 }
 add_action( 'edit_category', 'courtyard_category_transient_flusher' );
-add_action( 'save_post',     'courtyard_category_transient_flusher' );
+add_action( 'save_post', 'courtyard_category_transient_flusher' );

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -4,7 +4,7 @@
  *
  * Eventually, some of the functionality here could be replaced by core features.
  *
- * @package Courtyard
+ * @package mitlib-courtyard
  */
 
 if ( ! function_exists( 'courtyard_posted_on' ) ) :

--- a/inc/wpcom.php
+++ b/inc/wpcom.php
@@ -4,7 +4,7 @@
  *
  * This file is centrally included from `wp-content/mu-plugins/wpcom-theme-compat.php`.
  *
- * @package Courtyard
+ * @package mitlib-courtyard
  */
 
 /**

--- a/index.php
+++ b/index.php
@@ -9,7 +9,7 @@
  *
  * @link https://codex.wordpress.org/Template_Hierarchy
  *
- * @package Courtyard
+ * @package mitlib-courtyard
  */
 
 get_header(); ?>

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "courtyard",
-  "version": "0.1.0",
+  "name": "mitlib-courtyard",
+  "version": "1.2.0",
   "description": "Build tooling for the MIT Libraries' 'courtyard' Wordpress theme.",
-  "bugs": "https://github.com/MITLibraries/courtyard/issues",
+  "bugs": "https://github.com/MITLibraries/mitlib-courtyard/issues",
   "license": "MIT",
   "repository" : {
     "type": "git",
-    "url": "https://github.com/MITLibraries/courtyard"
+    "url": "https://github.com/MITLibraries/mitlib-courtyard"
   },
   "devDependencies": {
     "glob": "~7.1.2",

--- a/page.php
+++ b/page.php
@@ -9,7 +9,7 @@
  *
  * @link https://codex.wordpress.org/Template_Hierarchy
  *
- * @package Courtyard
+ * @package mitlib-courtyard
  */
 
 get_header(); ?>

--- a/sass/style.scss
+++ b/sass/style.scss
@@ -1,5 +1,5 @@
 /*
-Theme Name: Courtyard
+Theme Name: mitlib-courtyard
 Theme URI:
 Author:
 Author URI:

--- a/search.php
+++ b/search.php
@@ -4,7 +4,7 @@
  *
  * @link https://developer.wordpress.org/themes/basics/template-hierarchy/#search-result
  *
- * @package Courtyard
+ * @package mitlib-courtyard
  */
 
 get_header(); ?>

--- a/searchform.php
+++ b/searchform.php
@@ -2,7 +2,7 @@
 /**
  * The template for displaying search forms in Courtyard
  *
- * @package Courtyard
+ * @package mitlib-courtyard
  */
 
 ?>

--- a/sidebar.php
+++ b/sidebar.php
@@ -4,7 +4,7 @@
  *
  * @link https://developer.wordpress.org/themes/basics/template-files/#template-partials
  *
- * @package Courtyard
+ * @package mitlib-courtyard
  */
 
 if ( ! is_active_sidebar( 'sidebar-1' ) ) {

--- a/single.php
+++ b/single.php
@@ -4,7 +4,7 @@
  *
  * @link https://developer.wordpress.org/themes/basics/template-hierarchy/#single-post
  *
- * @package Courtyard
+ * @package mitlib-courtyard
  */
 
 get_header(); ?>

--- a/style.css
+++ b/style.css
@@ -1,10 +1,10 @@
 /*
-Theme Name: Courtyard
-Theme URI: https://github.com/MITLibraries/courtyard/
+Theme Name: MITlib Courtyard
+Theme URI: https://github.com/mitlibraries/mitlib-courtyard
 Author: Matt Bernhardt
 Author URI: http://github.com/matt-bernhardt/
 Description: This is a parent / base theme that is meant as a scaffold for child sites. It is based on _strap.
-Version: 1.1.1-@@branch-@@commit
+Version: 1.2.0-@@branch-@@commit
 License: GNU General Public License
 License URI: license.txt
 Tags: bootstrap, _s, _strap

--- a/style.less
+++ b/style.less
@@ -1,5 +1,5 @@
 /*
-Theme Name: Courtyard
+Theme Name: mitlib-courtyard
 Theme URI:
 Author:
 Author URI:

--- a/template-parts/content-none.php
+++ b/template-parts/content-none.php
@@ -4,7 +4,7 @@
  *
  * @link https://codex.wordpress.org/Template_Hierarchy
  *
- * @package Courtyard
+ * @package mitlib-courtyard
  */
 
 ?>

--- a/template-parts/content-page.php
+++ b/template-parts/content-page.php
@@ -4,7 +4,7 @@
  *
  * @link https://codex.wordpress.org/Template_Hierarchy
  *
- * @package Courtyard
+ * @package mitlib-courtyard
  */
 
 ?>

--- a/template-parts/content-search.php
+++ b/template-parts/content-search.php
@@ -4,7 +4,7 @@
  *
  * @link https://codex.wordpress.org/Template_Hierarchy
  *
- * @package Courtyard
+ * @package mitlib-courtyard
  */
 
 ?>

--- a/template-parts/content-single.php
+++ b/template-parts/content-single.php
@@ -4,7 +4,7 @@
  *
  * @link https://codex.wordpress.org/Template_Hierarchy
  *
- * @package Courtyard
+ * @package mitlib-courtyard
  */
 
 ?>

--- a/template-parts/content.php
+++ b/template-parts/content.php
@@ -4,7 +4,7 @@
  *
  * @link https://codex.wordpress.org/Template_Hierarchy
  *
- * @package Courtyard
+ * @package mitlib-courtyard
  */
 
 ?>


### PR DESCRIPTION
## Status
_Use labels (`review needed`, `in progress`, or `paused`) to declare status_

#### What does this PR do?
This renames the theme from `courtyard` to `mitlib-courtyard` to help avoid a name collision with the publicly-available Courtyard theme.

#### How can a reviewer manually see the effects of these changes?
By the time this review requests lands, this PR will be visible on both dev and test servers.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/NTI-188

#### Requires new or updated plugins, themes, or libraries?
SOMEWHAT - the Council site will need to be converted from the old theme to the new theme, and the old theme will need to be removed from the servers.

#### Requires change to deploy process?
NO
